### PR TITLE
Feat/create component radio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.31",
+  "version": "0.2.32",
   "name": "@alboompro/boom-components",
   "description": "React UI library containing a set of high quality components for building rich, interactive user interfaces in Alboom applications",
   "main": "index.js",
@@ -34,6 +34,10 @@
     {
       "name": "Elison de Campos",
       "email": "elison.campos@alboom.com.br"
+    },
+    {
+      "name": "Robson Formigão Gomes",
+      "email": "rformigao.gomes@gmail.com"
     }
   ],
   "license": "MIT",

--- a/size-snapshot.json
+++ b/size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "build/umd/boom-components.min.js": {
-    "bundled": 154232,
-    "minified": 52318,
-    "gzipped": 14199
+    "bundled": 156860,
+    "minified": 53624,
+    "gzipped": 14459
   }
 }

--- a/src/data-entry/radio/Radio.js
+++ b/src/data-entry/radio/Radio.js
@@ -1,24 +1,67 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Radio = ({ ...props }) => <div />;
+import { noop } from "../../helpers";
+
+import { Label, RadioButton } from "./styles";
+
+const Radio = ({
+  id,
+  name,
+  value,
+  defaultChecked,
+  label,
+  onChange,
+  disabled,
+  className,
+  style
+}) => (
+  <Label
+    htmlFor={id}
+    onChange={onChange}
+    disabled={disabled}
+    className={className}
+    style={style}
+  >
+    <RadioButton
+      disabled={disabled}
+      type="radio"
+      id={id}
+      name={name}
+      value={value}
+      defaultChecked={defaultChecked}
+    />
+    {label}
+  </Label>
+);
 
 Radio.propTypes = {
-  /** whether radio is selected */
-  checked: PropTypes.bool,
+  /** add custom className */
+  className: PropTypes.string,
   /** specifies the initial state of radio */
   defaultChecked: PropTypes.bool,
-  /** disabled status of radio */
+  /** disabled click of radio */
   disabled: PropTypes.bool,
-  /** for comparison, to determine whether is the selected  */
-  value: PropTypes.any
+  /** specifies id of radio */
+  id: PropTypes.string.isRequired,
+  /** label of radio */
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  /** name of radio group */
+  name: PropTypes.string.isRequired,
+  /** callback when click radio */
+  onChange: PropTypes.func,
+  /** component main style */
+  style: PropTypes.object,
+  /** value of radio when selected */
+  value: PropTypes.string.isRequired
 };
 
 Radio.defaultProps = {
-  checked: false,
+  className: "",
   defaultChecked: false,
   disabled: false,
-  value: null
+  onChange: noop,
+  style: null
 };
 
 export default Radio;

--- a/src/data-entry/radio/Radio.test.js
+++ b/src/data-entry/radio/Radio.test.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { mount } from "enzyme";
+import Radio from "./Radio";
+
+describe("Radio", () => {
+  test("Radio props", () => {
+    const wrapper = mount(
+      <Radio
+        className="radio-style"
+        defaultChecked
+        id="123"
+        label="Label de exemplo"
+        name="group-radio"
+        onChange={() => console.log("radio")}
+        value="Valor de exemplo"
+      />
+    );
+
+    expect(wrapper.props().className).toEqual("radio-style");
+    expect(wrapper.props().defaultChecked).toEqual(true);
+    expect(wrapper.props().id).toEqual("123");
+    expect(wrapper.props().label).toEqual("Label de exemplo");
+    expect(wrapper.props().name).toEqual("group-radio");
+    expect(wrapper.props().value).toEqual("Valor de exemplo");
+  });
+});

--- a/src/data-entry/radio/index.mdx
+++ b/src/data-entry/radio/index.mdx
@@ -4,12 +4,99 @@ menu: Data Entry
 ---
 
 import { Playground, Props } from 'docz'
+import Component from "react-component-component"
 
 import Radio from './Radio'
 
 # Radio
+ Radios são elementos que representam opções.
+ Geralmente, há um grupo deles que se refere ao mesmo contexto e apenas uma opção pode ser selecionada por grupo.
+## Quando utilizar
+* Varias opções mas apenas uma pode ser selecionada.
 
-Radio component.
+## Exemplos
+
+### Radio simples
+
+```jsx
+import Radio from "@alboom/boom-components/data-entry/radio";
+
+// Render...
+<div>
+  <Radio id="1" name="radio-simples" value="1" label="Sim" defaultChecked />
+  <Radio id="2" name="radio-simples" value="0" label="Não" />
+</div>
+```
+
+<Playground>
+  <Radio id="1" name="radio-simples" value="1" label="Sim" defaultChecked />
+  <Radio id="2" name="radio-simples" value="0" label="Não" />
+</Playground>
+
+### Utilizando onChange
+
+```jsx
+import Radio from "@alboom/boom-components/data-entry/radio";
+
+// Initial state
+this.state = {
+  value: '1'
+}
+
+// Render
+const { value } = this.state
+
+<div>
+  <Radio
+    id="3"
+    name="radio-onChange"
+    value="1"
+    label="Sim"
+    defaultChecked
+    onChange={e => this.setState({ value: e.target.value }) }
+  />
+  <Radio
+    id="4"
+    name="radio-onChange"
+    value="0"
+    label="Não"
+    onChange={e => this.setState({ value: e.target.value }) }
+  />
+
+  <span> Value selecionado: {value} </span>
+</div>
+```
+
+<Playground>
+  <Component
+    initialState={{ value: "1", options: [
+      { id: "3", name: "radio-onChange", value: "1", label: "Sim" },
+      { id: "4", name: "radio-onChange", value: "0", label: "Não" }
+    ]}}
+  >
+    {
+      ({ setState, state }) => (
+        <div>
+          <div style={ { display: 'flex' } }>
+            {state.options.map(option => (
+              <Radio
+                id={option.id}
+                name={option.name}
+                value={option.value}
+                label={option.label}
+                defaultChecked={state.value === option.value}
+                onChange={(e) => setState({ value: e.target.value })}
+                style={{ width: '80px', fontSize: '16px' }}
+              />
+            ))}
+          </div>
+
+          <span>Value selecionado: {state.value}</span>
+        </div>
+      )
+    }
+  </Component>
+</Playground>
 
 ## API
 

--- a/src/data-entry/radio/styles.js
+++ b/src/data-entry/radio/styles.js
@@ -1,0 +1,50 @@
+import styled from "styled-components";
+
+export const Label = styled.label`
+  display: flex;
+  align-items: center;
+  color: #444444;
+  font-size: 12px;
+  margin-right: 10px;
+
+  ${props =>
+    props.disabled
+      ? `
+      cursor: not-allowed;
+      opacity: .6;
+    `
+      : `
+      cursor: pointer;
+    `};
+`;
+
+export const RadioButton = styled.input`
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 1px solid #b7b7b7;
+  position: relative;
+  outline: none;
+  margin-right: 10px;
+
+  &:checked {
+    &::after {
+      content: "";
+      width: 8px;
+      height: 8px;
+      position: absolute;
+      background-color: #44adf8;
+      position: absolute;
+      border-radius: 50%;
+      top: 2px;
+      left: 2px;
+    }
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+`;


### PR DESCRIPTION
# Radio
 Radios são elementos que representam opções.
 Geralmente, há um grupo deles que se refere ao mesmo contexto e apenas uma opção pode ser selecionada por grupo.

## Quando utilizar
* Varias opções mas apenas uma pode ser selecionada.

## Exemplos

### Radio simples

```jsx
import Radio from "@alboom/boom-components/data-entry/radio";
// Render...
<div>
  <Radio id="1" name="radio-simples" value="1" label="Sim" defaultChecked />
  <Radio id="2" name="radio-simples" value="0" label="Não" />
</div>
```
### Resultado
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/52428165/70647360-86daa600-1c27-11ea-8209-21efe4a92913.gif)
