### PR TITLE
bugfix/49 - changed some imports to correctly correspond file

### DIFF
--- a/src/data-display/collapse/index.mdx
+++ b/src/data-display/collapse/index.mdx
@@ -7,7 +7,7 @@ import { Playground, Props } from 'docz'
 
 import Collapse from './Collapse'
 import Panel from "./Panel"
-import Icon from "../../general/Icon"
+import Icon from "../../general/icon"
 
 # Collapse
 

--- a/src/data-entry/autocomplete/index.mdx
+++ b/src/data-entry/autocomplete/index.mdx
@@ -5,7 +5,7 @@ menu: Data Entry
 
 import { Playground, Props } from 'docz'
 
-import Autocomplete from './Autocomplete'
+import Autocomplete from './AutoComplete'
 
 # Autocomplete
 


### PR DESCRIPTION
Now `yarn docs` compiles

![image](https://user-images.githubusercontent.com/56794007/122957300-2d911e00-d358-11eb-9197-6e9b97c007ab.png)
