### PR TITLE
Feat - TextAreaMode, lengthCounter, suffixInfo, and description

### DIFF
--- a/size-snapshot.json
+++ b/size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "build/umd/boom-components.min.js": {
-    "bundled": 166053,
-    "minified": 56952,
-    "gzipped": 15255
+    "bundled": 176710,
+    "minified": 61611,
+    "gzipped": 16427
   }
 }

--- a/src/data-entry/input/Input.js
+++ b/src/data-entry/input/Input.js
@@ -1,178 +1,14 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-import { connect, Field } from "formik";
-import Icon from "../../general/icon/Icon";
+import { connect } from "formik";
+import { DefaultDataEntryText } from "../../shared/data-entry-text";
 
-import {
-  DefaultInputContainer,
-  Label,
-  InputContent,
-  InputField,
-  ErrorLabel,
-  InputIcon,
-  ClearebleIcon,
-  InputDefault,
-  Description,
-  InputSuffix,
-  InputSuffixLabel,
-  InfoSuffixLabel,
-  InputSuffixCounter,
-  InputTextArea
-} from "./styles";
+import { InputDefault } from "./styles";
 
-export class DefaultInput extends Component {
-  state = {
-    value: ""
-  };
-
-  onKeyDown = e => {
-    const { onPressEnter, onKeyPress } = this.props;
-    const keycode = e.keyCode ? e.keyCode : e.which;
-
-    if (onPressEnter && (e.key === "Enter" || keycode === "13")) {
-      onPressEnter(e);
-    }
-
-    if (onKeyPress) {
-      onKeyPress(e);
-    }
-  };
-
-  cleanInput = () => {
-    const { name, clearable, formik } = this.props;
-    let defaultContent = "";
-
-    if (typeof clearable === "function") {
-      defaultContent = clearable();
-    }
-
-    if (formik) {
-      formik.setFieldValue(name, defaultContent, false);
-    } else {
-      this.setState({ value: defaultContent });
-    }
-  };
-
-  onChange = e => {
-    const { onChange, formik } = this.props;
-    if (typeof onChange === "function" && formik) {
-      onChange(e);
-    } else if (typeof onChange === "function") {
-      onChange(e, this);
-    } else {
-      onChange(e, this);
-      this.setState({ value: e.target.value });
-    }
-  };
-
-  getDefaultInput = inputProps => {
-    const { textAreaMode } = this.props;
-
-    if (textAreaMode) return <InputTextArea {...inputProps} />;
-
+export class DefaultInput extends DefaultDataEntryText {
+  getDataEntryType = inputProps => {
     return <InputDefault {...inputProps} />;
   };
-
-  render() {
-    const {
-      className,
-      clearable,
-      clearablePosition,
-      disabled,
-      error,
-      inputStyle,
-      label,
-      labelStyle,
-      name,
-      onBlur,
-      onKeyUp,
-      placeholder,
-      prefix,
-      readOnly,
-      suffix,
-      type,
-      value,
-      formik,
-      description,
-      infoSuffix,
-      maxLength,
-      showCounter
-    } = this.props;
-
-    const { value: stateValue } = this.state;
-    const inputProps = {
-      value: stateValue || value,
-      name,
-      type,
-      placeholder,
-      inputStyle,
-      disabled,
-      readOnly,
-      onKeyDown: this.onKeyDown,
-      onChange: this.onChange,
-      onKeyUp,
-      error
-    };
-
-    if (maxLength) inputProps.value = inputProps.value.substring(0, maxLength);
-
-    if (onBlur) inputProps.onBlur = onBlur;
-
-    return (
-      <DefaultInputContainer error={error} className={className}>
-        {label && <Label labelStyle={labelStyle}>{label}</Label>}
-        {description && <Description>{description}</Description>}
-        <InputContent error={error}>
-          {prefix && <InputIcon prefix={prefix}>{prefix}</InputIcon>}
-          {suffix && (
-            <InputIcon suffix={suffix} clearable={clearable}>
-              {suffix}
-            </InputIcon>
-          )}
-          <InputField prefix={prefix} suffix={suffix} clearable={clearable}>
-            {formik ? (
-              <Field
-                name={name}
-                render={({ field }) => {
-                  return this.getDefaultInput({ ...inputProps, ...field });
-                }}
-              />
-            ) : (
-              this.getDefaultInput(inputProps)
-            )}
-            {inputProps.value && clearable && (
-              <ClearebleIcon
-                clearablePosition={clearablePosition}
-                onClick={() => this.cleanInput()}
-              >
-                <Icon
-                  kind="bold"
-                  group="interface-essential"
-                  category="form-validation"
-                  file="close.svg"
-                  size="13"
-                  color="c9c9c9"
-                />
-              </ClearebleIcon>
-            )}
-          </InputField>
-        </InputContent>
-        <InputSuffix>
-          <InputSuffixLabel>
-            {error && error.message && <ErrorLabel>{error.message}</ErrorLabel>}
-            {infoSuffix && infoSuffix && (
-              <InfoSuffixLabel>{infoSuffix}</InfoSuffixLabel>
-            )}
-          </InputSuffixLabel>
-          {maxLength && showCounter && (
-            <InputSuffixCounter>
-              {inputProps.value.length}/{maxLength}
-            </InputSuffixCounter>
-          )}
-        </InputSuffix>
-      </DefaultInputContainer>
-    );
-  }
 }
 
 /**
@@ -183,36 +19,7 @@ export class DefaultInput extends Component {
  */
 
 DefaultInput.propTypes = {
-  /** set className to input */
-  className: PropTypes.string,
-  /** whether input content can be removed with clear icon, pass boolean or default value of input */
-  clearable: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
-  /** clearable position style */
-  clearablePosition: PropTypes.string,
-  /** disabled state of the input */
-  disabled: PropTypes.bool,
-  /** error status, if has error return pass boolean value to flag input or pass object like {message: "error message"} with message text */
-  error: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
-  /** input custom style */
-  inputStyle: PropTypes.object,
-  /** label custom style */
-  labelStyle: PropTypes.object,
-  /** callback on input blur */
-  onBlur: PropTypes.func,
-  /** callback when value changes */
-  onChange: PropTypes.func,
-  /** callback when enter key is pressed */
-  onPressEnter: PropTypes.func,
-  /** callback when key is pressed */
-  onKeyPress: PropTypes.func,
-  /** callback on key up */
-  onKeyUp: PropTypes.func,
-  /** prefix icon inside input */
-  prefix: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  /** set readonly prop */
-  readOnly: PropTypes.bool,
-  /** suffix icon inside input */
-  suffix: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  ...DefaultDataEntryText.propTypes,
   /** HTML type of input */
   type: PropTypes.oneOf([
     "email",
@@ -223,44 +30,12 @@ DefaultInput.propTypes = {
     "text",
     "url",
     "week"
-  ]),
-  /** input content value */
-  value: PropTypes.string,
-  /** input description */
-  description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  /** info suffix, after input */
-  infoSuffix: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  /** limit input length */
-  maxLength: PropTypes.number,
-  /** show counter if maxLength is setted */
-  showCounter: PropTypes.bool,
-  /** set input as textarea  */
-  textAreaMode: PropTypes.bool
+  ])
 };
 
 DefaultInput.defaultProps = {
-  className: "",
-  clearable: null,
-  clearablePosition: null,
-  disabled: false,
-  error: null,
-  inputStyle: null,
-  labelStyle: null,
-  onBlur: null,
-  onChange: null,
-  onPressEnter: null,
-  onKeyPress: null,
-  onKeyUp: null,
-  prefix: null,
-  readOnly: false,
-  suffix: null,
-  type: "text",
-  value: "",
-  description: null,
-  infoSuffix: null,
-  maxLength: null,
-  showCounter: false,
-  textAreaMode: false
+  ...DefaultDataEntryText.defaultProps,
+  type: "text"
 };
 
 export default connect(DefaultInput);

--- a/src/data-entry/input/Input.js
+++ b/src/data-entry/input/Input.js
@@ -134,7 +134,7 @@ export class DefaultInput extends Component {
               <Field
                 name={name}
                 render={({ field }) => {
-                  return <InputDefault {...inputProps} {...field} />;
+                  return this.getDefaultInput({ ...inputProps, ...field });
                 }}
               />
             ) : (
@@ -234,7 +234,7 @@ DefaultInput.propTypes = {
   maxLength: PropTypes.number,
   /** show counter if maxLength is setted */
   showCounter: PropTypes.bool,
-  /** set input as textarea, does not work with formik  */
+  /** set input as textarea  */
   textAreaMode: PropTypes.bool
 };
 

--- a/src/data-entry/input/Input.js
+++ b/src/data-entry/input/Input.js
@@ -11,7 +11,13 @@ import {
   ErrorLabel,
   InputIcon,
   ClearebleIcon,
-  InputDefault
+  InputDefault,
+  Description,
+  InputSuffix,
+  InputSuffixLabel,
+  InfoSuffixLabel,
+  InputSuffixCounter,
+  InputTextArea
 } from "./styles";
 
 export class DefaultInput extends Component {
@@ -59,6 +65,14 @@ export class DefaultInput extends Component {
     }
   };
 
+  getDefaultInput = inputProps => {
+    const { textAreaMode } = this.props;
+
+    if (textAreaMode) return <InputTextArea {...inputProps} />;
+
+    return <InputDefault {...inputProps} />;
+  };
+
   render() {
     const {
       className,
@@ -78,7 +92,11 @@ export class DefaultInput extends Component {
       suffix,
       type,
       value,
-      formik
+      formik,
+      description,
+      infoSuffix,
+      maxLength,
+      showCounter
     } = this.props;
 
     const { value: stateValue } = this.state;
@@ -96,11 +114,14 @@ export class DefaultInput extends Component {
       error
     };
 
+    if (maxLength) inputProps.value = inputProps.value.substring(0, maxLength);
+
     if (onBlur) inputProps.onBlur = onBlur;
 
     return (
       <DefaultInputContainer error={error} className={className}>
         {label && <Label labelStyle={labelStyle}>{label}</Label>}
+        {description && <Description>{description}</Description>}
         <InputContent error={error}>
           {prefix && <InputIcon prefix={prefix}>{prefix}</InputIcon>}
           {suffix && (
@@ -117,7 +138,7 @@ export class DefaultInput extends Component {
                 }}
               />
             ) : (
-              <InputDefault {...inputProps} />
+              this.getDefaultInput(inputProps)
             )}
             {inputProps.value && clearable && (
               <ClearebleIcon
@@ -136,7 +157,19 @@ export class DefaultInput extends Component {
             )}
           </InputField>
         </InputContent>
-        {error && error.message && <ErrorLabel>{error.message}</ErrorLabel>}
+        <InputSuffix>
+          <InputSuffixLabel>
+            {error && error.message && <ErrorLabel>{error.message}</ErrorLabel>}
+            {infoSuffix && infoSuffix && (
+              <InfoSuffixLabel>{infoSuffix}</InfoSuffixLabel>
+            )}
+          </InputSuffixLabel>
+          {maxLength && showCounter && (
+            <InputSuffixCounter>
+              {inputProps.value.length}/{maxLength}
+            </InputSuffixCounter>
+          )}
+        </InputSuffix>
       </DefaultInputContainer>
     );
   }
@@ -192,7 +225,17 @@ DefaultInput.propTypes = {
     "week"
   ]),
   /** input content value */
-  value: PropTypes.string
+  value: PropTypes.string,
+  /** input description */
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** info suffix, after input */
+  infoSuffix: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** limit input length */
+  maxLength: PropTypes.number,
+  /** show counter if maxLength is setted */
+  showCounter: PropTypes.bool,
+  /** set input as textarea, does not work with formik  */
+  textAreaMode: PropTypes.bool
 };
 
 DefaultInput.defaultProps = {
@@ -212,7 +255,12 @@ DefaultInput.defaultProps = {
   readOnly: false,
   suffix: null,
   type: "text",
-  value: null
+  value: "",
+  description: null,
+  infoSuffix: null,
+  maxLength: null,
+  showCounter: false,
+  textAreaMode: false
 };
 
 export default connect(DefaultInput);

--- a/src/data-entry/input/index.mdx
+++ b/src/data-entry/input/index.mdx
@@ -202,7 +202,7 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
   </Formik>
 </Playground>
 
-### Imput style customizado
+### Input style customizado
 
 <Playground>
   <Formik
@@ -227,6 +227,117 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
   )} 
   </Formik>
 </Playground>
+
+### Input com descrição
+
+Podemos passar tanto uma string quanto um elemento Node para nossa descrição. Basta utilizarmos a propriedade `description`
+
+```jsx
+<DefaultInput
+  label="Input com descrição"
+  placeholder="Esse input tem uma descrição node"
+  description={
+    <div>Essa é uma descrição com um Node. <a href="#input-com-descrição">Saiba mais.</a></div>
+  }
+  infoSuffix="Podemos colocar alguma informação aqui, como um preview do input, ou um contador personalizado"
+/>
+```
+
+<Playground>
+  <DefaultInput
+    label="Input com descrição"
+    placeholder="Esse input tem uma descrição"
+    description={<div>Essa é uma descrição com um Node. <a href="#input-com-descrição">Saiba mais.</a></div>}
+    onChange={(e,instance) => {
+      instance.setState({ value: e.target.value });
+    }}
+  />
+</Playground>
+
+### Input com limite de caracteres
+
+Podemos definir um limite máximo de caracteres para o nosso input, passando as props `maxLength` e `showCounter={true}`
+
+```jsx
+<DefaultInput
+  label="Input com limite de caracteres"
+  placeholder="Esse input tem limite máximo de caracteres"
+  showCounter={true}
+  maxLength={25}
+/>
+```
+
+<Playground>
+  <DefaultInput
+    label="Input com limite de caracteres"
+    placeholder="Esse input tem limite máximo de caracteres"
+    showCounter={true}
+    maxLength={25}
+    onChange={(e,instance) => {
+      instance.setState({ value: e.target.value });
+    }}
+  />
+</Playground>
+
+### Input com informação em seu sufixo
+
+Caso precisemos definir um sufixo para nosso input, podemos passá-lo utilizando a propriedade `infoSuffix`
+
+```jsx
+<DefaultInput
+  label="Input com sufixo"
+  placeholder="Esse input tem um sufixo"
+  infoSuffix="Podemos definir um sufixo dessa forma."
+/>
+```
+
+<Playground>
+  <DefaultInput
+    label="Input com sufixo"
+    placeholder="Esse input tem um sufixo"
+    infoSuffix="Podemos definir um sufixo dessa forma."
+    onChange={(e,instance) => {
+      instance.setState({ value: e.target.value });
+    }}
+  />
+</Playground>
+
+Em caso de erro, o sufixo ficará abaixo da mensagem de erro:
+<Playground>
+  <DefaultInput
+    label="Input com sufixo"
+    placeholder="Esse input tem um sufixo"
+    infoSuffix="Podemos definir um sufixo dessa forma."
+    error={{message: "Nesse caso, temos um erro"}}
+    onChange={(e,instance) => {
+      instance.setState({ value: e.target.value });
+    }}
+  />
+</Playground>
+
+### Input como textarea
+
+Se for necessário, podemos trocar nosso input por um textarea, passando a flag `textAreaMode={true}`. Este modo não funciona com o formik
+
+```jsx
+<DefaultInput
+  label="Input como text area"
+  placeholder="Esse input é um textarea"
+  textAreaMode={true}
+/>
+```
+
+<Playground>
+  <DefaultInput
+    label="Input como text area"
+    placeholder="Esse input é um textarea"
+    textAreaMode={true}
+    onChange={(e,instance) => {
+      instance.setState({ value: e.target.value });
+    }}
+  />
+</Playground>
+
 
 ## API
 

--- a/src/data-entry/input/index.mdx
+++ b/src/data-entry/input/index.mdx
@@ -317,7 +317,7 @@ Em caso de erro, o sufixo ficará abaixo da mensagem de erro:
 
 ### Input como textarea
 
-Se for necessário, podemos trocar nosso input por um textarea, passando a flag `textAreaMode={true}`. Este modo não funciona com o formik
+Se for necessário, podemos trocar nosso input por um textarea, passando a flag `textAreaMode={true}`
 
 ```jsx
 <DefaultInput
@@ -338,6 +338,35 @@ Se for necessário, podemos trocar nosso input por um textarea, passando a flag 
   />
 </Playground>
 
+Também pode ser implementado com o Formik
+
+<Playground>
+  <Formik
+    initialValues={{ "field1": "", "field2": "" }}
+    onSubmit={(values) => {
+      console.log(values)
+    }}
+  >
+    {({handleChange, setFieldValue, values}) => (
+      <Form>
+        <Input
+          name="field1"
+          onChange={handleChange}
+          label="Esse é um input comum"
+          clearable
+        />
+        <Input
+          name="field2"
+          onChange={handleChange}
+          label="Esse é um textarea"
+          textAreaMode={true}
+          clearable
+        />
+        <Button htmlType="submit" type={"primary"} style={{ marginTop: 10, fontSize: 12 }}>Submit</Button>
+      </Form>
+    )} 
+  </Formik>
+</Playground>
 
 ## API
 

--- a/src/data-entry/input/styles.js
+++ b/src/data-entry/input/styles.js
@@ -14,7 +14,16 @@ const inputSettings = update("input", {
   inputFontSize: "14px",
   inputErrorSize: "11px",
   inputPaddingError: "17px",
-  errorColor: "#FF5252"
+  errorColor: "#FF5252",
+  errorMinHeight: "17px",
+  errorPadding: "5px 0 0",
+  descriptionSize: "12px",
+  descriptionMargin: "0 0 5px",
+  infoSuffixPadding: "5px 0 0",
+  infoSuffixSize: "11px",
+  counterColor: "#858585",
+  counterSize: "11px",
+  counterPadding: "5px 0 0"
 });
 
 export const DefaultInputContainer = styled.div`
@@ -72,6 +81,35 @@ export const InputDefault = styled.input`
   ${props => props.inputStyle}
 `;
 
+/**
+ * Only works in styled-components v4+
+ */
+// export const InputTextArea = styled(InputDefault).attrs({ as: "textarea" })`
+//   resize: none;
+// `;
+
+export const InputTextArea = styled.textarea`
+  /// Equals to InputDefault
+  width: 100%;
+  padding: ${inputSettings.inputPadding};
+  color: ${inputSettings.inputColor};
+  font-size: ${inputSettings.inputFontSize};
+  border: none;
+  background-color: #fff;
+  border: ${inputSettings.inputBorder};
+  border-radius: ${inputSettings.inputBorderRadius};
+  &:focus{
+    outline: none;
+  }
+  ${props =>
+    props.error ? `border-color: ${inputSettings.errorColor};` : null}
+  ${props => (props.disabled ? "opacity: 0.8;" : null)}
+  ${props => props.inputStyle}
+
+  /// Own props
+  resize: none;
+`;
+
 export const InputField = styled.div`
   display: flex;
   align-items: center;
@@ -79,7 +117,8 @@ export const InputField = styled.div`
 `;
 
 export const ErrorLabel = styled.div`
-  min-height: ${inputSettings.inputPaddingError};
+  min-height: ${inputSettings.errorMinHeight};
+  padding: ${inputSettings.errorPadding};
   color: ${inputSettings.errorColor};
   font-size: ${inputSettings.inputErrorSize};
 `;
@@ -95,4 +134,31 @@ export const ClearebleIcon = styled.span`
   user-select: none;
   ${props =>
     props.clearablePosition ? `right: ${props.clearablePosition};` : null}
+`;
+
+export const Description = styled.div`
+  color: #7d7d7d;
+  font-size: ${inputSettings.descriptionSize};
+  margin: ${inputSettings.descriptionMargin};
+`;
+
+export const InputSuffix = styled.div`
+  display: flex;
+`;
+
+export const InputSuffixLabel = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const InfoSuffixLabel = styled.div`
+  padding: ${inputSettings.infoSuffixPadding};
+  font-size: ${inputSettings.infoSuffixSize};
+`;
+
+export const InputSuffixCounter = styled.div`
+  font-size: ${inputSettings.counterSize};
+  color: ${inputSettings.counterColor};
+  padding: ${inputSettings.counterPadding};
 `;

--- a/src/data-entry/textarea/Textarea.js
+++ b/src/data-entry/textarea/Textarea.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { connect } from "formik";
+import { DefaultDataEntryText } from "../../shared/data-entry-text";
+
+import { Textarea } from "./styles";
+
+export class DefaultTextArea extends DefaultDataEntryText {
+  getDataEntryType = inputProps => {
+    return <Textarea {...inputProps} />;
+  };
+}
+
+/**
+ * Basic text field to get user input.
+ *
+ * @param {*} { size, ...props }
+ * @returns {Component}
+ */
+DefaultTextArea.propTypes = { ...DefaultDataEntryText.propTypes };
+
+DefaultTextArea.defaultProps = { ...DefaultDataEntryText.defaultProps };
+
+export default connect(DefaultTextArea);

--- a/src/data-entry/textarea/Textarea.test.js
+++ b/src/data-entry/textarea/Textarea.test.js
@@ -1,0 +1,54 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Formik, Form } from "formik";
+import Textarea, { DefaultTextArea } from "./Textarea";
+
+describe("Textarea", () => {
+  test("textarea props", () => {
+    const wrapper = mount(
+      <DefaultTextArea
+        name="field1"
+        label="textarea Test"
+        type="text"
+        value="Text"
+        clearable
+        readOnly
+        error
+      />
+    );
+
+    const textarea = wrapper.find("textarea");
+    const label = wrapper.find("label");
+
+    expect(textarea.props().name).toEqual("field1");
+    expect(textarea.props().type).toEqual("text");
+    expect(textarea.props().value).toEqual("Text");
+    expect(textarea.props().readOnly).toEqual(true);
+    expect(label.props().children).toEqual("textarea Test");
+  });
+
+  test("formik textarea props", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ field1: "Text" }}>
+        <Form>
+          <Textarea
+            name="field1"
+            label="textarea Test"
+            type="text"
+            value="Text"
+            readOnly
+          />
+        </Form>
+      </Formik>
+    );
+
+    const textarea = wrapper.find("textarea");
+    const label = wrapper.find("label");
+
+    expect(textarea.props().name).toEqual("field1");
+    expect(textarea.props().type).toEqual("text");
+    expect(textarea.props().value).toEqual("Text");
+    expect(textarea.props().readOnly).toEqual(true);
+    expect(label.props().children).toEqual("textarea Test");
+  });
+});

--- a/src/data-entry/textarea/index.js
+++ b/src/data-entry/textarea/index.js
@@ -1,0 +1,1 @@
+export { default, DefaultTextArea } from "./Textarea";

--- a/src/data-entry/textarea/index.mdx
+++ b/src/data-entry/textarea/index.mdx
@@ -1,35 +1,34 @@
 ---
-name: Input
+name: Textarea
 menu: Data Entry
 ---
 
 import { Playground, Props } from 'docz'
 import { Formik, Form, Field, ErrorMessage } from 'formik'
 
-import Input, { DefaultInput } from './Input'
+import Textarea, { DefaultTextArea } from './Textarea'
 import { DefaultDataEntryText } from "../../shared/data-entry-text";
 import Icon from '../../general/icon/Icon'
 import Button from '../../general/button/Button'
 
-# Input
+# Textarea
 
-Inputs são campos usados para entrada de dados em forma de texto. Inputs geralmente são usados em conjunto dentro de um Form, e podem conter uma label, o campo input e um retorno de erro.
-
-## Quando utilizar
-* Construir Forms
+Textareas são campos usados para entrada de dados em forma de texto, aceitando multiplas linhas.
 
 ## Dependências
-O DefaultInput não possui dependências.
-O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
+O DefaultTextArea não possui dependências.<br/>
+O Textarea possui o [Formik](https://github.com/jaredpalmer/formik) como dependência.
 
 ## Exemplos
 
-### exemplo de input simples
+De forma geral, o Textarea aceita todos os parâmetros vistos na [sessão do Textarea](./data-entry-textarea-index), com excessão de propriedades que são exclusivas do textarea, como a `type`.
+
+### exemplo de textarea simples
 ```jsx
-<DefaultInput
+<DefaultTextArea
   name="simpleInput"
-  value="simple input default value"
-  label="Simple input example"
+  value="simple textarea default value"
+  label="Simple textarea example"
   onChange={(e,instance) => {
     console.log(e.target.value);
     instance.setState({ value: e.target.value });
@@ -37,30 +36,30 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
 />
 ```
 
-### exemplo de input com formik implementado
+### exemplo de textarea com formik implementado
 ```jsx
-<Input
+<Textarea
   name="formikInputField"
-  value="simple input using formik"
-  label="Simple input formik example"
+  value="simple textarea using formik"
+  label="Simple textarea formik example"
 />
 ```
 
 ### Uso básico
 <Playground>
   <div>
-  <DefaultInput
+  <DefaultTextArea
     name="fieldName"
-    label="Basic input example"
+    label="Basic textarea example"
     error={false}
     value={"teste"}
     onChange={(e,instance) => {
       instance.setState({ value: e.target.value });
     }}
   />
-  <DefaultInput
+  <DefaultTextArea
     name="fieldName"
-    label="Basic input example"
+    label="Basic textarea example"
     error={false}
     onChange={(e,instance) => {
       instance.setState({ value: e.target.value });
@@ -74,22 +73,22 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
   >
   {({handleChange, setFieldValue, values}) => (
     <Form>
-      <Input
+      <Textarea
         name="field1"
         onChange={handleChange}
-        label="Basic usage input field"
+        label="Basic usage textarea field"
         clearable
       />
-       <Input
+       <Textarea
         name="field2"
         onChange={handleChange}
-        label="Basic usage input field disabled"
+        label="Basic usage textarea field disabled"
         disabled
       />
-      <Input
+      <Textarea
         name="field3"
         onChange={handleChange}
-        label="Basic usage input field with readonly"
+        label="Basic usage textarea field with readonly"
         readonly
       />
       <Button htmlType="submit" type={"primary"} style={{ marginTop: 10, fontSize: 12 }}>Submit</Button>
@@ -110,10 +109,10 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
   >
   {({handleChange, setFieldValue, values}) => (
     <Form> 
-      <Input 
+      <Textarea 
         name="field1"
         value={values.field1}
-        label="Input using Prefix" 
+        label="Textarea using Prefix" 
         onChange={handleChange}
         inputStyle={{"paddingLeft": 25}}
         prefix={<Icon
@@ -125,10 +124,10 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
           color="45AE70"
         />} 
       />
-      <Input 
+      <Textarea 
         name="field2"
         value={values.field2}
-        label="Input using Suffix" 
+        label="Textarea using Suffix" 
         onChange={handleChange}
         inputStyle={{"paddingRight": 25}}
         suffix={<Icon
@@ -140,10 +139,10 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
           color="45AE70"
         />} 
       />
-      <Input 
+      <Textarea 
         name="field3"
         value={values.field3}
-        label="Input using Suffix and clearable" 
+        label="Textarea using Suffix and clearable" 
         onChange={handleChange}
         inputStyle={{"paddingRight": 50}}
         clearablePosition={"30px"}
@@ -157,10 +156,10 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
           color="45AE70"
         />} 
       />
-      <Input 
+      <Textarea 
         name="field4"
         value={values.field4}
-        label="Input using clearable" 
+        label="Textarea using clearable" 
         onChange={handleChange}
         inputStyle={{"paddingRight": 25}}
         clearablePosition={"7px"}
@@ -183,17 +182,17 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
   >
   {({handleChange, setFieldValue, values}) => (
     <Form> 
-      <Input 
+      <Textarea 
         name="field1"
         value={values.field1}
-        label="Input using error with message" 
+        label="Textarea using error with message" 
         onChange={handleChange}
         error={{message: "Message error example"}}
       />
-      <Input 
+      <Textarea 
         name="field2"
         value={values.field2}
-        label="Input using default error"
+        label="Textarea using default error"
         onChange={handleChange}
         error
       />
@@ -203,7 +202,7 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
   </Formik>
 </Playground>
 
-### Input style customizado
+### Textarea style customizado
 
 <Playground>
   <Formik
@@ -214,10 +213,10 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
   >
   {({handleChange, setFieldValue, values}) => (
     <Form> 
-      <Input 
+      <Textarea 
         name="field1"
         value={values.field1}
-        label="Input with custom style"
+        label="Textarea with custom style"
         inputStyle={{borderColor: "#45ae70", fontSize: 20, color: "#FF5252"}} 
         labelStyle={{fontSize: 10, color: "#45ae70"}}
         onChange={handleChange}
@@ -229,49 +228,49 @@ O Input tem o [Formik](https://github.com/jaredpalmer/formik) como dependência.
   </Formik>
 </Playground>
 
-### Input com descrição
+### Textarea com descrição
 
 Podemos passar tanto uma string quanto um elemento Node para nossa descrição. Basta utilizarmos a propriedade `description`
 
 ```jsx
-<DefaultInput
-  label="Input com descrição"
-  placeholder="Esse input tem uma descrição node"
+<DefaultTextArea
+  label="Textarea com descrição"
+  placeholder="Esse textarea tem uma descrição node"
   description={
-    <div>Essa é uma descrição com um Node. <a href="#input-com-descrição">Saiba mais.</a></div>
+    <div>Essa é uma descrição com um Node. <a href="#textarea-com-descrição">Saiba mais.</a></div>
   }
-  infoSuffix="Podemos colocar alguma informação aqui, como um preview do input, ou um contador personalizado"
+  infoSuffix="Podemos colocar alguma informação aqui, como um preview do textarea, ou um contador personalizado"
 />
 ```
 
 <Playground>
-  <DefaultInput
-    label="Input com descrição"
-    placeholder="Esse input tem uma descrição"
-    description={<div>Essa é uma descrição com um Node. <a href="#input-com-descrição">Saiba mais.</a></div>}
+  <DefaultTextArea
+    label="Textarea com descrição"
+    placeholder="Esse textarea tem uma descrição"
+    description={<div>Essa é uma descrição com um Node. <a href="#textarea-com-descrição">Saiba mais.</a></div>}
     onChange={(e,instance) => {
       instance.setState({ value: e.target.value });
     }}
   />
 </Playground>
 
-### Input com limite de caracteres
+### Textarea com limite de caracteres
 
-Podemos definir um limite máximo de caracteres para o nosso input, passando as props `maxLength` e `showCounter={true}`
+Podemos definir um limite máximo de caracteres para o nosso textarea, passando as props `maxLength` e `showCounter={true}`
 
 ```jsx
-<DefaultInput
-  label="Input com limite de caracteres"
-  placeholder="Esse input tem limite máximo de caracteres"
+<DefaultTextArea
+  label="Textarea com limite de caracteres"
+  placeholder="Esse textarea tem limite máximo de caracteres"
   showCounter={true}
   maxLength={25}
 />
 ```
 
 <Playground>
-  <DefaultInput
-    label="Input com limite de caracteres"
-    placeholder="Esse input tem limite máximo de caracteres"
+  <DefaultTextArea
+    label="Textarea com limite de caracteres"
+    placeholder="Esse textarea tem limite máximo de caracteres"
     showCounter={true}
     maxLength={25}
     onChange={(e,instance) => {
@@ -280,22 +279,22 @@ Podemos definir um limite máximo de caracteres para o nosso input, passando as 
   />
 </Playground>
 
-### Input com informação em seu sufixo
+### Textarea com informação em seu sufixo
 
-Caso precisemos definir um sufixo para nosso input, podemos passá-lo utilizando a propriedade `infoSuffix`
+Caso precisemos definir um sufixo para nosso textarea, podemos passá-lo utilizando a propriedade `infoSuffix`
 
 ```jsx
-<DefaultInput
-  label="Input com sufixo"
-  placeholder="Esse input tem um sufixo"
+<DefaultTextArea
+  label="Textarea com sufixo"
+  placeholder="Esse textarea tem um sufixo"
   infoSuffix="Podemos definir um sufixo dessa forma."
 />
 ```
 
 <Playground>
-  <DefaultInput
-    label="Input com sufixo"
-    placeholder="Esse input tem um sufixo"
+  <DefaultTextArea
+    label="Textarea com sufixo"
+    placeholder="Esse textarea tem um sufixo"
     infoSuffix="Podemos definir um sufixo dessa forma."
     onChange={(e,instance) => {
       instance.setState({ value: e.target.value });
@@ -305,9 +304,9 @@ Caso precisemos definir um sufixo para nosso input, podemos passá-lo utilizando
 
 Em caso de erro, o sufixo ficará abaixo da mensagem de erro:
 <Playground>
-  <DefaultInput
-    label="Input com sufixo"
-    placeholder="Esse input tem um sufixo"
+  <DefaultTextArea
+    label="Textarea com sufixo"
+    placeholder="Esse textarea tem um sufixo"
     infoSuffix="Podemos definir um sufixo dessa forma."
     error={{message: "Nesse caso, temos um erro"}}
     onChange={(e,instance) => {
@@ -316,7 +315,57 @@ Em caso de erro, o sufixo ficará abaixo da mensagem de erro:
   />
 </Playground>
 
+### Textarea como textarea
+
+Se for necessário, podemos trocar nosso textarea por um textarea, passando a flag `textAreaMode={true}`
+
+```jsx
+<DefaultTextArea
+  label="Textarea como text area"
+  placeholder="Esse textarea é um textarea"
+/>
+```
+
+<Playground>
+  <DefaultTextArea
+    label="Textarea como text area"
+    placeholder="Esse textarea é um textarea"
+    onChange={(e,instance) => {
+      instance.setState({ value: e.target.value });
+    }}
+  />
+</Playground>
+
+Também pode ser implementado com o Formik
+
+<Playground>
+  <Formik
+    initialValues={{ "field1": "", "field2": "" }}
+    onSubmit={(values) => {
+      console.log(values)
+    }}
+  >
+    {({handleChange, setFieldValue, values}) => (
+      <Form>
+        <Textarea
+          name="field1"
+          onChange={handleChange}
+          label="Esse é um textarea comum"
+          clearable
+        />
+        <DefaultTextArea
+          name="field2"
+          onChange={handleChange}
+          label="Esse é um textarea"
+          clearable
+        />
+        <Button htmlType="submit" type={"primary"} style={{ marginTop: 10, fontSize: 12 }}>Submit</Button>
+      </Form>
+    )} 
+  </Formik>
+</Playground>
+
 ## API
 
-<Props of={Input} />
+<Props of={Textarea} />
 <Props of={DefaultDataEntryText} />

--- a/src/data-entry/textarea/styles.js
+++ b/src/data-entry/textarea/styles.js
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+import { DefaultDataEntryCSS } from "../../shared/data-entry-text";
+
+export const Textarea = styled.textarea`
+  ${DefaultDataEntryCSS};
+
+  resize: none;
+`;

--- a/src/shared/data-entry-text/index.js
+++ b/src/shared/data-entry-text/index.js
@@ -1,0 +1,246 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Field } from "formik";
+import Icon from "../../general/icon/Icon";
+
+import {
+  DefaultDataEntryTextContainer,
+  Label,
+  InputContent,
+  InputField,
+  ErrorLabel,
+  InputIcon,
+  ClearebleIcon,
+  Description,
+  InputSuffix,
+  InputSuffixLabel,
+  HelpTextLabel,
+  InputSuffixCounter,
+  DefaultDataEntryCSS,
+  inputSettings as InputSettingsCSS
+} from "./styles";
+
+export class DefaultDataEntryText extends Component {
+  state = {
+    value: ""
+  };
+
+  getDataEntryType = inputProps => {
+    throw "Must be implemented";
+  };
+
+  onKeyDown = e => {
+    const { onPressEnter, onKeyPress } = this.props;
+    const keycode = e.keyCode ? e.keyCode : e.which;
+
+    if (onPressEnter && (e.key === "Enter" || keycode === "13")) {
+      onPressEnter(e);
+    }
+
+    if (onKeyPress) {
+      onKeyPress(e);
+    }
+  };
+
+  cleanInput = () => {
+    const { name, clearable, formik } = this.props;
+    let defaultContent = "";
+
+    if (typeof clearable === "function") {
+      defaultContent = clearable();
+    }
+
+    if (formik) {
+      formik.setFieldValue(name, defaultContent, false);
+    } else {
+      this.setState({ value: defaultContent });
+    }
+  };
+
+  onChange = e => {
+    const { onChange, formik } = this.props;
+    if (typeof onChange === "function" && formik) {
+      onChange(e);
+    } else if (typeof onChange === "function") {
+      onChange(e, this);
+    } else {
+      onChange(e, this);
+      this.setState({ value: e.target.value });
+    }
+  };
+
+  render() {
+    const {
+      className,
+      clearable,
+      clearablePosition,
+      disabled,
+      error,
+      inputStyle,
+      label,
+      labelStyle,
+      name,
+      onBlur,
+      onKeyUp,
+      placeholder,
+      prefix,
+      readOnly,
+      suffix,
+      type,
+      value,
+      formik,
+      description,
+      helpText,
+      maxLength,
+      showCounter
+    } = this.props;
+
+    const { value: stateValue } = this.state;
+    const inputProps = {
+      value: stateValue || value,
+      name,
+      type,
+      placeholder,
+      inputStyle,
+      disabled,
+      readOnly,
+      onKeyDown: this.onKeyDown,
+      onChange: this.onChange,
+      onKeyUp,
+      error
+    };
+
+    if (maxLength) inputProps.value = inputProps.value.substring(0, maxLength);
+
+    if (onBlur) inputProps.onBlur = onBlur;
+
+    return (
+      <DefaultDataEntryTextContainer error={error} className={className}>
+        {label && <Label labelStyle={labelStyle}>{label}</Label>}
+        {description && <Description>{description}</Description>}
+        <InputContent error={error}>
+          {prefix && <InputIcon prefix={prefix}>{prefix}</InputIcon>}
+          {suffix && (
+            <InputIcon suffix={suffix} clearable={clearable}>
+              {suffix}
+            </InputIcon>
+          )}
+          <InputField prefix={prefix} suffix={suffix} clearable={clearable}>
+            {formik ? (
+              <Field
+                name={name}
+                render={({ field }) => {
+                  return this.getDataEntryType({ ...inputProps, ...field });
+                }}
+              />
+            ) : (
+              this.getDataEntryType(inputProps)
+            )}
+            {inputProps.value && clearable && (
+              <ClearebleIcon
+                clearablePosition={clearablePosition}
+                onClick={() => this.cleanInput()}
+              >
+                <Icon
+                  kind="bold"
+                  group="interface-essential"
+                  category="form-validation"
+                  file="close.svg"
+                  size="13"
+                  color="c9c9c9"
+                />
+              </ClearebleIcon>
+            )}
+          </InputField>
+        </InputContent>
+        <InputSuffix>
+          <InputSuffixLabel>
+            {error && error.message && <ErrorLabel>{error.message}</ErrorLabel>}
+            {helpText && helpText && <HelpTextLabel>{helpText}</HelpTextLabel>}
+          </InputSuffixLabel>
+          {maxLength && showCounter && (
+            <InputSuffixCounter>
+              {inputProps.value.length}/{maxLength}
+            </InputSuffixCounter>
+          )}
+        </InputSuffix>
+      </DefaultDataEntryTextContainer>
+    );
+  }
+}
+
+/**
+ * Basic text field to get user input.
+ *
+ * @param {*} { size, ...props }
+ * @returns {Component}
+ */
+
+DefaultDataEntryText.propTypes = {
+  /** set className to input */
+  className: PropTypes.string,
+  /** whether input content can be removed with clear icon, pass boolean or default value of input */
+  clearable: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+  /** clearable position style */
+  clearablePosition: PropTypes.string,
+  /** disabled state of the input */
+  disabled: PropTypes.bool,
+  /** error status, if has error return pass boolean value to flag input or pass object like {message: "error message"} with message text */
+  error: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+  /** input custom style */
+  inputStyle: PropTypes.object,
+  /** label custom style */
+  labelStyle: PropTypes.object,
+  /** callback on input blur */
+  onBlur: PropTypes.func,
+  /** callback when value changes */
+  onChange: PropTypes.func,
+  /** callback when enter key is pressed */
+  onPressEnter: PropTypes.func,
+  /** callback when key is pressed */
+  onKeyPress: PropTypes.func,
+  /** callback on key up */
+  onKeyUp: PropTypes.func,
+  /** prefix icon inside input */
+  prefix: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** set readonly prop */
+  readOnly: PropTypes.bool,
+  /** suffix icon inside input */
+  suffix: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** input content value */
+  value: PropTypes.string,
+  /** input description */
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** info suffix, after input */
+  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** limit input length */
+  maxLength: PropTypes.number,
+  /** show counter if maxLength is setted */
+  showCounter: PropTypes.bool
+};
+
+DefaultDataEntryText.defaultProps = {
+  className: "",
+  clearable: null,
+  clearablePosition: null,
+  disabled: false,
+  error: null,
+  inputStyle: null,
+  labelStyle: null,
+  onBlur: null,
+  onChange: null,
+  onPressEnter: null,
+  onKeyPress: null,
+  onKeyUp: null,
+  prefix: null,
+  readOnly: false,
+  suffix: null,
+  value: "",
+  description: null,
+  helpText: null,
+  maxLength: null,
+  showCounter: false
+};
+
+export { DefaultDataEntryCSS, InputSettingsCSS };
+export default DefaultDataEntryText;

--- a/src/shared/data-entry-text/styles.js
+++ b/src/shared/data-entry-text/styles.js
@@ -1,0 +1,135 @@
+import styled, { css } from "styled-components";
+import { update } from "../../settings";
+
+export const inputSettings = update("input", {
+  labelMargin: "0 0 5px",
+  labelColor: "#000",
+  labelSize: "14px",
+  labelLineHeight: "16px",
+  inputBorder: "1px solid #c9c9c9",
+  inputBorderRadius: "1px",
+  inputMarginBottom: "8px",
+  inputColor: "#1e1e1e",
+  inputPadding: "8px 15px",
+  inputFontSize: "14px",
+  inputErrorSize: "11px",
+  inputPaddingError: "17px",
+  errorColor: "#FF5252",
+  errorMinHeight: "17px",
+  errorPadding: "5px 0 0",
+  descriptionSize: "12px",
+  descriptionMargin: "0 0 5px",
+  helpTextPadding: "5px 0 0",
+  helpTextSize: "11px",
+  counterColor: "#858585",
+  counterSize: "11px",
+  counterPadding: "5px 0 0"
+});
+
+export const DefaultDataEntryCSS = css`
+  width: 100%;
+  padding: ${inputSettings.inputPadding};
+  color: ${inputSettings.inputColor};
+  font-size: ${inputSettings.inputFontSize};
+  border: none;
+  background-color: #fff;
+  border: ${inputSettings.inputBorder};
+  border-radius: ${inputSettings.inputBorderRadius};
+  &:focus{
+    outline: none;
+  } 
+  ${props =>
+    props.error ? `border-color: ${inputSettings.errorColor};` : null}
+  ${props => (props.disabled ? "opacity: 0.8;" : null)}
+  ${props => props.inputStyle}
+`;
+
+export const DefaultDataEntryTextContainer = styled.div`
+  * {
+    box-sizing: border-box;
+  }
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: ${inputSettings.inputPaddingError};
+  margin-bottom: ${inputSettings.inputMarginBottom};
+  ${props => (props.error && props.error.message ? "padding-bottom: 0" : null)};
+`;
+
+export const Label = styled.label`
+  margin: ${inputSettings.labelMargin};
+  color: ${inputSettings.labelColor};
+  font-size: ${inputSettings.labelSize};
+  line-height: ${inputSettings.labelLineHeight};
+  ${props => (props.labelStyle ? props.labelStyle : null)}
+`;
+
+export const InputContent = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  width: 100%;
+`;
+
+export const InputIcon = styled.span`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  height: 100%;
+  user-select: none;
+  ${props => props.prefix && "left: 7px;"}
+  ${props => props.suffix && "right: 7px;"}
+`;
+
+export const InputField = styled.div`
+  display: flex;
+  align-items: center;
+  flex: 1;
+`;
+
+export const ErrorLabel = styled.div`
+  min-height: ${inputSettings.errorMinHeight};
+  padding: ${inputSettings.errorPadding};
+  color: ${inputSettings.errorColor};
+  font-size: ${inputSettings.inputErrorSize};
+`;
+
+export const ClearebleIcon = styled.span`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  right: 10px;
+  margin: 0 0 0 5px;
+  height: 100%;
+  cursor: pointer;
+  user-select: none;
+  ${props =>
+    props.clearablePosition ? `right: ${props.clearablePosition};` : null}
+`;
+
+export const Description = styled.div`
+  color: #7d7d7d;
+  font-size: ${inputSettings.descriptionSize};
+  margin: ${inputSettings.descriptionMargin};
+`;
+
+export const InputSuffix = styled.div`
+  display: flex;
+`;
+
+export const InputSuffixLabel = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const HelpTextLabel = styled.div`
+  padding: ${inputSettings.helpTextPadding};
+  font-size: ${inputSettings.helpTextSize};
+`;
+
+export const InputSuffixCounter = styled.div`
+  font-size: ${inputSettings.counterSize};
+  color: ${inputSettings.counterColor};
+  padding: ${inputSettings.counterPadding};
+`;


### PR DESCRIPTION
Foram implementados novas opções para o data-entry/input, sendo elas:
`maxLength`: Limita o tamanho máximo de caracteres do input;
`showCounter`: Mostra o limite de caracteres e o length atual (também precisa definir o maxLength para funcionar);
`textAreaMode`: Substitui o input para um textarea (não funciona em conjunto com o formik);
`infoSuffix`: Mostra um texto/node após o input;
`description`: Mostra um texto/node entre o label (título) e o input.

![image](https://user-images.githubusercontent.com/56794007/124515934-fe969580-ddb6-11eb-9c52-60981223d009.png)
![image](https://user-images.githubusercontent.com/56794007/124515952-09e9c100-ddb7-11eb-8b02-c3ed04923d3f.png)
![image](https://user-images.githubusercontent.com/56794007/124515960-0eae7500-ddb7-11eb-84f3-7cb4abcd0f56.png)
![image](https://user-images.githubusercontent.com/56794007/124515970-19690a00-ddb7-11eb-9c26-69bf8bab36c7.png)
![image](https://user-images.githubusercontent.com/56794007/124515985-1ff78180-ddb7-11eb-8fc3-6e94fdd0d204.png)
